### PR TITLE
Add Towny requirements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,4 +41,5 @@ dependencies {
         exclude group: 'com.sk89q.worldguard'
     }
     compile 'com.github.Ben12345rocks:VotingPlugin:5.18.2'
+    compile 'com.github.LlmDl:Towny:25fc18a'
 }

--- a/src/main/java/sh/okx/rankup/Rankup.java
+++ b/src/main/java/sh/okx/rankup/Rankup.java
@@ -37,6 +37,7 @@ import sh.okx.rankup.requirements.requirement.advancedachievements.AdvancedAchie
 import sh.okx.rankup.requirements.requirement.advancedachievements.AdvancedAchievementsTotalRequirement;
 import sh.okx.rankup.requirements.requirement.mcmmo.McMMOPowerLevelRequirement;
 import sh.okx.rankup.requirements.requirement.mcmmo.McMMOSkillRequirement;
+import sh.okx.rankup.requirements.requirement.towny.*;
 import sh.okx.rankup.requirements.requirement.votingplugin.VotingPluginVotesRequirement;
 
 import java.io.File;
@@ -241,6 +242,14 @@ public class Rankup extends JavaPlugin {
     }
     if (Bukkit.getPluginManager().isPluginEnabled("VotingPlugin")) {
       requirementRegistry.addRequirement(new VotingPluginVotesRequirement(this));
+    }
+    if (Bukkit.getPluginManager().isPluginEnabled("Towny")) {
+      requirementRegistry.addRequirement(new TownyResidentRequirement(this));
+      requirementRegistry.addRequirement(new TownyMayorRequirement(this));
+      requirementRegistry.addRequirement(new TownyMayorNumberResidentsRequirement(this));
+      requirementRegistry.addRequirement(new TownyKingRequirement(this));
+      requirementRegistry.addRequirement(new TownyKingNumberResidentsRequirement(this));
+      requirementRegistry.addRequirement(new TownyKingNumberTownsRequirement(this));
     }
     requirementRegistry.addRequirement(new ItemRequirement(this));
     requirementRegistry.addRequirement(new UseItemRequirement(this));

--- a/src/main/java/sh/okx/rankup/requirements/Requirement.java
+++ b/src/main/java/sh/okx/rankup/requirements/Requirement.java
@@ -61,6 +61,10 @@ public abstract class Requirement implements Cloneable {
     return Integer.parseInt(value);
   }
 
+  public boolean getValueBoolean() {
+    return Boolean.parseBoolean(value);
+  }
+
   public String getFullName() {
     if (hasSubRequirement()) {
       return name + "#" + sub;

--- a/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyKingNumberResidentsRequirement.java
+++ b/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyKingNumberResidentsRequirement.java
@@ -1,0 +1,30 @@
+package sh.okx.rankup.requirements.requirement.towny;
+
+import org.bukkit.entity.Player;
+import sh.okx.rankup.Rankup;
+import sh.okx.rankup.requirements.ProgressiveRequirement;
+import sh.okx.rankup.requirements.Requirement;
+
+public class TownyKingNumberResidentsRequirement extends ProgressiveRequirement {
+  public TownyKingNumberResidentsRequirement(Rankup plugin) {
+    super(plugin, "towny-king-residents");
+  }
+
+  protected TownyKingNumberResidentsRequirement(Requirement clone) {
+    super(clone);
+  }
+
+  @Override
+  public double getProgress(Player player) {
+    if (TownyUtils.getInstance().isKing(player)) {
+      return TownyUtils.getInstance().getNation(player).getNumResidents();
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public Requirement clone() {
+    return new TownyKingNumberResidentsRequirement(this);
+  }
+}

--- a/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyKingNumberTownsRequirement.java
+++ b/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyKingNumberTownsRequirement.java
@@ -1,0 +1,30 @@
+package sh.okx.rankup.requirements.requirement.towny;
+
+import org.bukkit.entity.Player;
+import sh.okx.rankup.Rankup;
+import sh.okx.rankup.requirements.ProgressiveRequirement;
+import sh.okx.rankup.requirements.Requirement;
+
+public class TownyKingNumberTownsRequirement extends ProgressiveRequirement {
+  public TownyKingNumberTownsRequirement(Rankup plugin) {
+    super(plugin, "towny-king-towns");
+  }
+
+  protected TownyKingNumberTownsRequirement(Requirement clone) {
+    super(clone);
+  }
+
+  @Override
+  public double getProgress(Player player) {
+    if (TownyUtils.getInstance().isKing(player)) {
+      return TownyUtils.getInstance().getNation(player).getNumTowns();
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public Requirement clone() {
+    return new TownyKingNumberTownsRequirement(this);
+  }
+}

--- a/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyKingRequirement.java
+++ b/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyKingRequirement.java
@@ -1,0 +1,25 @@
+package sh.okx.rankup.requirements.requirement.towny;
+
+import org.bukkit.entity.Player;
+import sh.okx.rankup.Rankup;
+import sh.okx.rankup.requirements.Requirement;
+
+public class TownyKingRequirement extends Requirement {
+  public TownyKingRequirement(Rankup plugin) {
+    super(plugin, "towny-king");
+  }
+
+  protected TownyKingRequirement(Requirement clone) {
+    super(clone);
+  }
+
+  @Override
+  public boolean check(Player player) {
+    return TownyUtils.getInstance().isKing(player) == getValueBoolean();
+  }
+
+  @Override
+  public Requirement clone() {
+    return new TownyKingRequirement(this);
+  }
+}

--- a/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyMayorNumberResidentsRequirement.java
+++ b/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyMayorNumberResidentsRequirement.java
@@ -1,0 +1,30 @@
+package sh.okx.rankup.requirements.requirement.towny;
+
+import org.bukkit.entity.Player;
+import sh.okx.rankup.Rankup;
+import sh.okx.rankup.requirements.ProgressiveRequirement;
+import sh.okx.rankup.requirements.Requirement;
+
+public class TownyMayorNumberResidentsRequirement extends ProgressiveRequirement {
+  public TownyMayorNumberResidentsRequirement(Rankup plugin) {
+    super(plugin, "towny-mayor-residents");
+  }
+
+  protected TownyMayorNumberResidentsRequirement(Requirement clone) {
+    super(clone);
+  }
+
+  @Override
+  public double getProgress(Player player) {
+    if (TownyUtils.getInstance().isMayor(player)) {
+      return TownyUtils.getInstance().getTown(player).getNumResidents();
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public Requirement clone() {
+    return new TownyMayorNumberResidentsRequirement(this);
+  }
+}

--- a/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyMayorRequirement.java
+++ b/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyMayorRequirement.java
@@ -1,0 +1,25 @@
+package sh.okx.rankup.requirements.requirement.towny;
+
+import org.bukkit.entity.Player;
+import sh.okx.rankup.Rankup;
+import sh.okx.rankup.requirements.Requirement;
+
+public class TownyMayorRequirement extends Requirement {
+  public TownyMayorRequirement(Rankup plugin) {
+    super(plugin, "towny-mayor");
+  }
+
+  protected TownyMayorRequirement(Requirement clone) {
+    super(clone);
+  }
+
+  @Override
+  public boolean check(Player player) {
+    return TownyUtils.getInstance().isMayor(player) == getValueBoolean();
+  }
+
+  @Override
+  public Requirement clone() {
+    return new TownyMayorRequirement(this);
+  }
+}

--- a/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyResidentRequirement.java
+++ b/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyResidentRequirement.java
@@ -1,0 +1,29 @@
+package sh.okx.rankup.requirements.requirement.towny;
+
+import org.bukkit.entity.Player;
+import sh.okx.rankup.Rankup;
+import sh.okx.rankup.requirements.Requirement;
+
+public class TownyResidentRequirement extends Requirement {
+  public TownyResidentRequirement(Rankup plugin) {
+    super(plugin, "towny-resident");
+  }
+
+  public TownyResidentRequirement(Rankup plugin, String name) {
+    super(plugin, name);
+  }
+
+  protected TownyResidentRequirement(Requirement clone) {
+    super(clone);
+  }
+
+  @Override
+  public boolean check(Player player) {
+    return  TownyUtils.getInstance().isResident(player);
+  }
+
+  @Override
+  public Requirement clone() {
+    return new TownyResidentRequirement(this);
+  }
+}

--- a/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyResidentRequirement.java
+++ b/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyResidentRequirement.java
@@ -9,17 +9,13 @@ public class TownyResidentRequirement extends Requirement {
     super(plugin, "towny-resident");
   }
 
-  public TownyResidentRequirement(Rankup plugin, String name) {
-    super(plugin, name);
-  }
-
   protected TownyResidentRequirement(Requirement clone) {
     super(clone);
   }
 
   @Override
   public boolean check(Player player) {
-    return  TownyUtils.getInstance().isResident(player);
+    return TownyUtils.getInstance().isResident(player) == getValueBoolean();
   }
 
   @Override

--- a/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyUtils.java
+++ b/src/main/java/sh/okx/rankup/requirements/requirement/towny/TownyUtils.java
@@ -1,0 +1,71 @@
+package sh.okx.rankup.requirements.requirement.towny;
+
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import org.bukkit.entity.Player;
+
+public class TownyUtils {
+    private static TownyUtils instance;
+
+    public static TownyUtils getInstance() {
+        if (instance == null) {
+            instance = new TownyUtils();
+        }
+        return instance;
+    }
+
+    public boolean isResident(Player player) {
+        try {
+            Town town = TownyUniverse.getDataSource().getResident(player.getName()).getTown();
+
+            return town != null;
+        } catch (NotRegisteredException e) {
+            return false;
+        }
+    }
+
+    public Resident getResident(Player player) {
+        try {
+            return TownyUniverse.getDataSource().getResident(player.getName());
+        } catch (NotRegisteredException e) {
+            return null;
+        }
+    }
+
+    public Town getTown(Player player) {
+        try {
+            return TownyUniverse.getDataSource().getResident(player.getName()).getTown();
+        } catch (NotRegisteredException e) {
+            return null;
+        }
+    }
+
+    public Nation getNation(Player player) {
+        Town town = getTown(player);
+
+        try {
+            return getTown(player) == null ? null : town.getNation();
+        } catch (NotRegisteredException e) {
+            return null;
+        }
+    }
+
+    public boolean isMayor(Player player) {
+        try {
+            return TownyUniverse.getDataSource().getResident(player.getName()).isMayor();
+        } catch (NotRegisteredException e) {
+            return false;
+        }
+    }
+
+    public boolean isKing(Player player) {
+        try {
+            return TownyUniverse.getDataSource().getResident(player.getName()).isKing();
+        } catch (NotRegisteredException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: 3.5.4
 main: sh.okx.rankup.Rankup
 author: Okx
 depend: [Vault]
-softdepend: [PlaceholderAPI, mcMMO, AdvancedAchievements]
+softdepend: [PlaceholderAPI, mcMMO, AdvancedAchievements, Towny]
 api-version: 1.13
 
 commands:


### PR DESCRIPTION
Hello, plugin is pretty cool.
I added some requirements for [Towny](http://towny.palmergames.com/).

New requirements:
- towny-resident {true}/{false}   => The player (does not) need to be a resident of a town
- towny-mayor {true}/{false}   => The player (does not) need to be the mayor of a town
- towny-king {true}/{false}   => The player (does not) need to be the king of a nation
- towny-mayor-residents {number}   => The player's town (need to be mayor) need to have at least {number} residents
- towny-king-residents {number}   => The player's nation (need to be king) need to have at least {number} residents
- towny-king-towns {number}   => The player's nation (need to be king) need to have at least {number} towns